### PR TITLE
🦾 :전체 캘린더 반환형식 수정

### DIFF
--- a/calendar/calendar/src/main/java/org/aba2/calendar/common/domain/calendar/business/CalendarBusiness.java
+++ b/calendar/calendar/src/main/java/org/aba2/calendar/common/domain/calendar/business/CalendarBusiness.java
@@ -18,6 +18,7 @@ import org.aba2.calendar.common.exception.ApiException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 @Business
@@ -47,12 +48,16 @@ public class CalendarBusiness {
         var groupSchedules = calendarService.getGroupScheduleList(userId);
 
         // 두 일정을 합쳐 반환
-        var allSchedules = Stream.concat(personalSchedules.stream(), groupSchedules.stream())
+        return Stream.concat(personalSchedules.stream(), groupSchedules.stream())
                 .map(calendarConverter::toResponse)
                 .toList();
-        return allSchedules;
+
     }
 
+    public Map<String, List<Map<String, String>>> getMainScheduleListForFrontend(String userId) {
+        var allSchedules = getMainScheduleList(userId);
+        return calendarConverter.convertToFrontendFormat(allSchedules);
+    }
 
 
     //개인 스케줄 등록

--- a/calendar/calendar/src/main/java/org/aba2/calendar/common/domain/calendar/controller/CalendarApiController.java
+++ b/calendar/calendar/src/main/java/org/aba2/calendar/common/domain/calendar/controller/CalendarApiController.java
@@ -13,6 +13,7 @@ import org.aba2.calendar.common.domain.user.model.User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/calendar")
@@ -24,12 +25,12 @@ public class CalendarApiController {
 
     //전체 스케줄 조회
     @GetMapping
-    public Api<List<CalendarResponse>> getMainScheduleList(
+    public Api<Map<String, List<Map<String, String>>>> getMainScheduleListForFrontend(
             @UserSession User user
     ){
         log.debug("Fetching main schedule list for user: {}", user.getId());
 
-        return Api.OK(calendarBusiness.getMainScheduleList(user.getId()));
+        return Api.OK(calendarBusiness.getMainScheduleListForFrontend(user.getId()));
     }
 
     //개인 캘린더 조회
@@ -64,24 +65,6 @@ public class CalendarApiController {
         Api<CalendarResponse> response = Api.OK(calendarBusiness.register(req, user));
         return ResponseEntity.ok(response);
 
-//        try {
-//            // 정상적으로 요청이 처리되었을 때
-//            CalendarResponse response = calendarBusiness.register(req, user);
-//            return ResponseEntity.ok(Api.OK(response));
-//        } catch (ApiException e) {
-//            e.printStackTrace();
-//            // ApiException 발생 시, 에러 코드와 설명을 포함하여 응답을 생성
-//            Api<?> errorResponse = Api.ERROR(e.getErrorCodeIfs());
-//            // ResponseEntity로 변환할 때, 제네릭 타입을 Api<CalendarResponse>로 변경
-//            return ResponseEntity.badRequest().body((Api<CalendarResponse>) errorResponse);
-//        } catch (Exception e) {
-//            e.printStackTrace();
-//            // 일반적인 예외 발생 시, 에러 코드와 설명을 포함하여 응답을 생성
-//            Api<?> errorResponse = Api.ERROR(CalendarErrorCode.UNKNOWN_ERROR);
-//            // ResponseEntity로 변환할 때, 제네릭 타입을 Api<CalendarResponse>로 변경
-//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-//                    .body((Api<CalendarResponse>) errorResponse);
-//        }
     }
 
 
@@ -158,10 +141,6 @@ public class CalendarApiController {
         calendarBusiness.deleteGroupCalendar(calId, req.getGroupId(), user);
         return ResponseEntity.ok(null);
     }
-
-
-
-
 
 
 

--- a/calendar/calendar/src/main/java/org/aba2/calendar/common/domain/calendar/converter/CalendarConverter.java
+++ b/calendar/calendar/src/main/java/org/aba2/calendar/common/domain/calendar/converter/CalendarConverter.java
@@ -16,6 +16,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Converter
 public class CalendarConverter {
@@ -118,6 +122,19 @@ public class CalendarConverter {
     }
 
 
+
+    public Map<String, List<Map<String, String>>> convertToFrontendFormat(List<CalendarResponse> schedules) {
+        return schedules.stream()
+                .collect(Collectors.groupingBy(
+                        schedule -> schedule.getStartDate().toString(),
+                        Collectors.mapping(schedule -> {
+                            Map<String, String> scheduleMap = new HashMap<>();
+                            scheduleMap.put("color", schedule.getColor().toString());
+                            scheduleMap.put("title", schedule.getTitle());
+                            return scheduleMap;
+                        }, Collectors.toList())
+                ));
+    }
 
 
 


### PR DESCRIPTION
전체 캘린더 데이터 반환 형식 데이터 손실 최소화 하여 보냄
전체 데이터를 보냈던걸 

> '2024-12-01': [
>         { color: 'red', title: '회의' },
>         { color: 'blue', title: '운동' }
>     ],

위 형식으로 수정함